### PR TITLE
newSendersAPI

### DIFF
--- a/BaselineOfTelePharo.package/BaselineOfTelePharo.class/instance/baseline..st
+++ b/BaselineOfTelePharo.package/BaselineOfTelePharo.class/instance/baseline..st
@@ -9,7 +9,7 @@ baseline: spec
 		spec project: 'SeamlessForClient' copyFrom: 'Seamless' with: [
 				spec loads: 'default'	].
 		spec baseline: 'Calypso' with: [ 
-			spec repository: 'github://dionisiydk/Calypso:v0.8.x' ].
+			spec repository: 'github://dionisiydk/Calypso:v0.9.x' ].
 		spec project: 'CalypsoEnvironment' copyFrom: 'Calypso' with: [
 				spec loads: 'FullEnvironment' ].
 		spec project: 'CalypsoBrowser' copyFrom: 'Calypso' with: [

--- a/TelePharo-Browser-Client.package/TlpSystemBrowser.extension/instance/browseImplementorsOf..st
+++ b/TelePharo-Browser-Client.package/TlpSystemBrowser.extension/instance/browseImplementorsOf..st
@@ -1,4 +1,4 @@
 *TelePharo-Browser-Client
 browseImplementorsOf: aSelector 
 
-	self spawnQueryBrowserOn: (ClyMessageImplementors of: {aSelector})
+	self spawnQueryBrowserOn: (ClyMessageImplementors of: aSelector)

--- a/TelePharo-Browser-Client.package/TlpSystemBrowser.extension/instance/browseReferencesTo..st
+++ b/TelePharo-Browser-Client.package/TlpSystemBrowser.extension/instance/browseReferencesTo..st
@@ -5,6 +5,6 @@ browseReferencesTo: aSelector
 	aSelector first isUppercase ifTrue: [ 
 		classBinding := self systemEnvironment bindingOf: aSelector.
 		classBinding ifNotNil: [ 
-			^self spawnQueryBrowserOn: (ClyClassReferences of: {classBinding})]].
+			^self spawnQueryBrowserOn: (ClyClassReferences of: classBinding)]].
 		
 	self browseSendersOf: aSelector

--- a/TelePharo-Browser-Client.package/TlpSystemBrowser.extension/instance/browseSendersOf..st
+++ b/TelePharo-Browser-Client.package/TlpSystemBrowser.extension/instance/browseSendersOf..st
@@ -1,4 +1,4 @@
 *TelePharo-Browser-Client
 browseSendersOf: aSelector
 
-	self spawnQueryBrowserOn: (ClyMessageSenders of: {aSelector})
+	self spawnQueryBrowserOn: (ClyMessageSenders of: aSelector)


### PR DESCRIPTION
Senders, Implements and References  queries are changed instance creation API.
- #of: message and friends is now accept single item instead of array
- #ofAny: with friends are introduced to accept array of items.

So now it would be:
- ClyMessageSenders of: #do:
- ClyMessageImplementors ofAny: #(do asArray)