### PR TITLE
Fix remote doIt in playground with global references

### DIFF
--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/allClassVarNames.st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/allClassVarNames.st
@@ -1,3 +1,3 @@
-as yet unclassified
+class management
 allClassVarNames
 	^#()

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/allInstVarNames.st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/allInstVarNames.st
@@ -1,3 +1,3 @@
-as yet unclassified
+class management
 allInstVarNames
 	^#()

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/allSlots.st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/allSlots.st
@@ -1,3 +1,3 @@
-as yet unclassified
+class management
 allSlots
 	^#()

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/binding.st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/binding.st
@@ -1,3 +1,3 @@
-as yet unclassified
+binding
 binding
 	^nil class binding

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/findGlobalVariable.ifNone..st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/findGlobalVariable.ifNone..st
@@ -1,4 +1,4 @@
-as yet unclassified
+lookup
 findGlobalVariable: lookupBlock ifNone: notFoundBlock
 	"Normally it should scan remote globals for given block but it is too slow because of thousands network requests between block variables"
 	

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/innerBindingOf..st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/innerBindingOf..st
@@ -1,0 +1,3 @@
+binding
+innerBindingOf: aString 
+	^nil

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/instanceSide.st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/instanceSide.st
@@ -1,3 +1,3 @@
-as yet unclassified
+class management
 instanceSide
 	^self

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/seamlessIsBindingVisible..st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/seamlessIsBindingVisible..st
@@ -1,3 +1,3 @@
-as yet unclassified
+binding
 seamlessIsBindingVisible: aString
 	^false

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/theNonMetaClass.st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/theNonMetaClass.st
@@ -1,3 +1,3 @@
-as yet unclassified
+class management
 theNonMetaClass
 	^self


### PR DESCRIPTION
fix remote playground receiver TlpRemoteDoItReceiver to address changes of compiler in Pharo 7