### PR TITLE
Add CalypsoProcessBrowser in the baseline of TelePharo client

### DIFF
--- a/BaselineOfTelePharo.package/BaselineOfTelePharo.class/instance/baseline..st
+++ b/BaselineOfTelePharo.package/BaselineOfTelePharo.class/instance/baseline..st
@@ -17,7 +17,7 @@ baseline: spec
 				with: [ spec repository: 'github://pharo-ide/Calypso:v0.16.5/src' ].
 			spec
 				baseline: 'Seamless'
-				with: [ spec repository: 'github://pharo-ide/Seamless:v2.0.1' ].
+				with: [ spec repository: 'github://pharo-ide/Seamless:v2.0.2' ].
 			spec
 				project: 'SeamlessForServer'
 				copyFrom: 'Seamless'

--- a/BaselineOfTelePharo.package/BaselineOfTelePharo.class/instance/baseline..st
+++ b/BaselineOfTelePharo.package/BaselineOfTelePharo.class/instance/baseline..st
@@ -1,32 +1,78 @@
 baselines
 baseline: spec
 	<baseline>
-	spec for: #'common' do: [
-		spec baseline: 'Seamless' with: [ 
-			spec repository: 'github://pharo-ide/Seamless:v0.9.15' ].
-		spec project: 'SeamlessForServer' copyFrom: 'Seamless' with: [
-				spec loads: 'Core' ].
-		spec project: 'SeamlessForClient' copyFrom: 'Seamless' with: [
-				spec loads: 'default'	].
-		spec baseline: 'Calypso' with: [ 
-			spec repository: 'github://pharo-ide/Calypso:v0.16.1/src' ].
-		spec project: 'CalypsoMinimalEnvironment' copyFrom: 'Calypso' with: [
-				spec loads: #('MinimalEnvironment' 'ProcessEnvironment') ].
-		spec project: 'CalypsoFullEnvironment' copyFrom: 'Calypso' with: [
-				spec loads: #('FullEnvironment' 'ProcessEnvironment') ].
-		spec project: 'CalypsoBrowser' copyFrom: 'Calypso' with: [
-				spec loads: 'default'].				
-		spec baseline: 'StateSpecs' with: [
-				spec
-					repository: 'github://dionisiydk/StateSpecs:v2.4.10';
-					loads: #('StateSpecs-Specs' 'StateSpecs-DSL-ClassWords') ].
-				
-		spec package: 'TelePharo-Core' with: [spec requires: #('StateSpecs')].
-		spec package: 'TelePharo-Debugger' with: [spec requires: #('TelePharo-Core')].
-		spec package: 'TelePharo-Browser-Server' with: [spec requires: #('CalypsoMinimalEnvironment' 'TelePharo-Core')].
-		spec package: 'TelePharo-Browser-Client' with: [spec requires: #('TelePharo-Browser-Server' 'CalypsoBrowser')].
-		spec package: 'TelePharo-Playground' with: [spec requires: #('TelePharo-Core')].
-		spec
-			group: 'MinimalServer' with: #('SeamlessForServer' 'TelePharo-Core' 'TelePharo-Browser-Server' 'TelePharo-Debugger' ); 
-			group: 'Server' with: #('MinimalServer' 'CalypsoFullEnvironment');
-			group: 'Client' with: #('SeamlessForClient' 'TelePharo-Core' 'TelePharo-Browser-Client' 'TelePharo-Debugger' 'TelePharo-Playground')].
+	spec
+		for: #common
+		do: [ spec
+					baseline: 'Calypso'
+					with: [ spec repository: 'github://pharo-ide/Calypso:v0.16.5/src' ].
+			spec
+				project: 'CalypsoProcessBrowser'
+				copyFrom: 'Calypso'
+				with: [ spec loads: 'ProcessBrowser' ].
+			spec
+				baseline: 'Seamless'
+				with: [ spec repository: 'github://pharo-ide/Seamless:v2.0.1' ].
+			spec
+				project: 'SeamlessForServer'
+				copyFrom: 'Seamless'
+				with: [ spec loads: 'Core' ].
+			spec
+				project: 'SeamlessForClient'
+				copyFrom: 'Seamless'
+				with: [ spec loads: 'default' ].
+			spec
+				baseline: 'StateSpecs'
+				with: [ spec
+						repository: 'github://dionisiydk/StateSpecs:v4.0.2';
+						loads: #('StateSpecs-Specs' 'StateSpecs-DSL-ClassWords') ].
+			spec
+				for: #'pharo7.x'
+				do: [ "Dependencies for Pharo7, Calypso"
+					spec
+						baseline: 'Calypso'
+						with: [ spec repository: 'github://pharo-ide/Calypso:v0.16.5/src' ].
+					spec
+						project: 'CalypsoMinimalEnvironment'
+						copyFrom: 'Calypso'
+						with: [ spec loads: #('MinimalEnvironment' 'ProcessEnvironment') ].
+					spec
+						project: 'CalypsoFullEnvironment'
+						copyFrom: 'Calypso'
+						with: [ spec loads: #('FullEnvironment' 'ProcessEnvironment') ].
+					spec
+						project: 'CalypsoBrowser'
+						copyFrom: 'Calypso'
+						with: [ spec loads: 'default' ].
+					spec
+						group: 'Server'
+						with: #('MinimalServer' 'CalypsoFullEnvironment').
+					spec
+						package: 'TelePharo-Browser-Server'
+						with: [ spec requires: #('CalypsoMinimalEnvironment' 'TelePharo-Core') ].
+					spec
+						package: 'TelePharo-Browser-Client'
+						with: [ spec requires: #('TelePharo-Browser-Server' 'CalypsoBrowser') ] ].
+			spec
+				package: 'TelePharo-Core'
+				with: [ spec requires: #('StateSpecs') ].
+			spec
+				package: 'TelePharo-Debugger'
+				with: [ spec requires: #('TelePharo-Core') ].
+			spec
+				package: 'TelePharo-Browser-Server'
+				with: [ spec requires: #('TelePharo-Core') ].
+			spec
+				package: 'TelePharo-Browser-Client'
+				with: [ spec requires: #('TelePharo-Browser-Server') ].
+			spec
+				package: 'TelePharo-Playground'
+				with: [ spec requires: #('TelePharo-Core') ].
+			spec
+				group: 'MinimalServer'
+					with:
+					#('SeamlessForServer' 'TelePharo-Core' 'TelePharo-Browser-Server' 'TelePharo-Debugger');
+				group: 'Server' with: #('MinimalServer');
+				group: 'Client'
+					with:
+					#('SeamlessForClient' 'TelePharo-Core' 'TelePharo-Browser-Client' 'TelePharo-Debugger' 'TelePharo-Playground' 'CalypsoProcessBrowser') ].

--- a/BaselineOfTelePharo.package/BaselineOfTelePharo.class/instance/baseline..st
+++ b/BaselineOfTelePharo.package/BaselineOfTelePharo.class/instance/baseline..st
@@ -4,12 +4,17 @@ baseline: spec
 	spec
 		for: #common
 		do: [ spec
-					baseline: 'Calypso'
-					with: [ spec repository: 'github://pharo-ide/Calypso:v0.16.5/src' ].
+				package: 'Calypso-SystemTools-Debugger'
+				with: [ spec repository: 'github://pharo-ide/Calypso:v0.16.5/src' ].
 			spec
-				project: 'CalypsoProcessBrowser'
-				copyFrom: 'Calypso'
-				with: [ spec loads: 'ProcessBrowser' ].
+				package: 'Calypso-ProcessQueries'
+				with: [ spec repository: 'github://pharo-ide/Calypso:v0.16.5/src' ].
+			spec
+				package: 'Calypso-ProcessQueries-Tests'
+				with: [ spec repository: 'github://pharo-ide/Calypso:v0.16.5/src' ].
+			spec
+				package: 'Calypso-SystemTools-ProcessBrowser'
+				with: [ spec repository: 'github://pharo-ide/Calypso:v0.16.5/src' ].
 			spec
 				baseline: 'Seamless'
 				with: [ spec repository: 'github://pharo-ide/Seamless:v2.0.1' ].
@@ -69,10 +74,13 @@ baseline: spec
 				package: 'TelePharo-Playground'
 				with: [ spec requires: #('TelePharo-Core') ].
 			spec
+				group: 'Calypso-ProcessBrowser' 
+					with:
+					#('Calypso-SystemTools-Debugger' 'Calypso-ProcessQueries' 'Calypso-ProcessQueries-Tests' 'Calypso-SystemTools-ProcessBrowser');
 				group: 'MinimalServer'
 					with:
-					#('SeamlessForServer' 'TelePharo-Core' 'TelePharo-Browser-Server' 'TelePharo-Debugger');
+					#('SeamlessForServer' 'TelePharo-Core' 'TelePharo-Browser-Server' 'TelePharo-Debugger' 'Calypso-ProcessBrowser');
 				group: 'Server' with: #('MinimalServer');
 				group: 'Client'
 					with:
-					#('SeamlessForClient' 'TelePharo-Core' 'TelePharo-Browser-Client' 'TelePharo-Debugger' 'TelePharo-Playground' 'CalypsoProcessBrowser') ].
+					#('SeamlessForClient' 'TelePharo-Core' 'TelePharo-Browser-Client' 'TelePharo-Debugger' 'TelePharo-Playground' 'Calypso-ProcessBrowser') ]


### PR DESCRIPTION
In Pharo 8 it's not possible to use the Remote Process Browser because it is missing this package. 

https://github.com/pharo-ide/TelePharo/issues/31