### PR TITLE
 NewPlayground-remote-first-step

### DIFF
--- a/TelePharo-Playground.package/RemotePlaygroundInteractionModel.class/README.md
+++ b/TelePharo-Playground.package/RemotePlaygroundInteractionModel.class/README.md
@@ -1,0 +1,4 @@
+This subclass overrides #doItReceiver
+
+The compiler executes the method compiled for the doit on the receiver (using #withArgs:executeMethod:).
+By overriding that method, we execute the doit on the remote system

--- a/TelePharo-Playground.package/RemotePlaygroundInteractionModel.class/instance/bindingOf..st
+++ b/TelePharo-Playground.package/RemotePlaygroundInteractionModel.class/instance/bindingOf..st
@@ -1,0 +1,9 @@
+binding
+bindingOf: aString
+	| key |
+
+	key := aString asSymbol.
+	"if there is no binding, I will include a key"
+	(self localBindings includesKey: key)
+		ifFalse: [ self addBinding: (SeamlessRemoteWorkspaceVariable key: key) ].
+	^ self localBindings associationAt: key

--- a/TelePharo-Playground.package/RemotePlaygroundInteractionModel.class/instance/doItReceiver.st
+++ b/TelePharo-Playground.package/RemotePlaygroundInteractionModel.class/instance/doItReceiver.st
@@ -1,0 +1,3 @@
+accessing
+doItReceiver	
+	^TlpRemoteDoItReceiver for: owner owner page remotePharo

--- a/TelePharo-Playground.package/RemotePlaygroundInteractionModel.class/properties.json
+++ b/TelePharo-Playground.package/RemotePlaygroundInteractionModel.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "MarcusDenker 7/8/2021 15:20",
+	"super" : "StPlaygroundInteractionModel",
+	"category" : "TelePharo-Playground",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "RemotePlaygroundInteractionModel",
+	"type" : "normal"
+}

--- a/TelePharo-Playground.package/RemotePlaygroundPage.class/README.md
+++ b/TelePharo-Playground.package/RemotePlaygroundPage.class/README.md
@@ -1,0 +1,1 @@
+Subclass that is aware of the remotePharo to hand it over to the RemotePlaygroundPagePresenter by overriding #defaultObjectInspectorClass

--- a/TelePharo-Playground.package/RemotePlaygroundPage.class/instance/defaultObjectInspectorClass.st
+++ b/TelePharo-Playground.package/RemotePlaygroundPage.class/instance/defaultObjectInspectorClass.st
@@ -1,0 +1,7 @@
+inspector compatibility
+defaultObjectInspectorClass
+	"Since the playground can be the starting point of an inspection (using <meta+g>), the 
+	 playground page (which is the model of a playground) needs to behave as a valid starting point. 
+	 This method declares answer the presenter to use in the inspection miller list."
+
+	^ RemotePlaygroundPagePresenter

--- a/TelePharo-Playground.package/RemotePlaygroundPage.class/instance/remotePharo..st
+++ b/TelePharo-Playground.package/RemotePlaygroundPage.class/instance/remotePharo..st
@@ -1,0 +1,3 @@
+accessing
+remotePharo: anObject
+	remotePharo := anObject

--- a/TelePharo-Playground.package/RemotePlaygroundPage.class/instance/remotePharo.st
+++ b/TelePharo-Playground.package/RemotePlaygroundPage.class/instance/remotePharo.st
@@ -1,0 +1,4 @@
+accessing
+remotePharo
+
+	^ remotePharo

--- a/TelePharo-Playground.package/RemotePlaygroundPage.class/properties.json
+++ b/TelePharo-Playground.package/RemotePlaygroundPage.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "MarcusDenker 7/8/2021 15:21",
+	"super" : "StPlaygroundPage",
+	"category" : "TelePharo-Playground",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"remotePharo"
+	],
+	"name" : "RemotePlaygroundPage",
+	"type" : "normal"
+}

--- a/TelePharo-Playground.package/RemotePlaygroundPagePresenter.class/instance/initializePresenters.st
+++ b/TelePharo-Playground.package/RemotePlaygroundPagePresenter.class/instance/initializePresenters.st
@@ -1,0 +1,21 @@
+initialization
+initializePresenters
+
+	self initializeToolbar.
+	self initializeStatusbar.
+
+	(text := self newCode)
+		interactionModel: RemotePlaygroundInteractionModel new;
+		lineNumbers: self showLineNumbers;
+		overridingContextMenu;
+		contextMenu: [ (self menuActionsFor: text) asMenuPresenter ];
+		contextKeyBindings: (self menuActionsFor: text) asKMCategory;
+		whenTextChangedDo: [ :aString | page contents: aString ].
+		
+	text eventHandler 
+		whenKeyUpDo: [ :event | self updateLineNumber ];
+		whenMouseUpDo: [ :event | self updateLineNumber ];
+		"before taking focus position will be nil, ensure I have the correct one"
+		whenFocusReceivedDo: [ self updateLineNumber ].
+		
+	self updatePresenter

--- a/TelePharo-Playground.package/RemotePlaygroundPagePresenter.class/properties.json
+++ b/TelePharo-Playground.package/RemotePlaygroundPagePresenter.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "StPlaygroundPagePresenter",
+	"category" : "TelePharo-Playground",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "RemotePlaygroundPagePresenter",
+	"type" : "normal"
+}

--- a/TelePharo-Playground.package/TlpPlayground2.class/README.md
+++ b/TelePharo-Playground.package/TlpPlayground2.class/README.md
@@ -1,0 +1,1 @@
+Version if the newtools playground that works on the remote system.

--- a/TelePharo-Playground.package/TlpPlayground2.class/class/openFor..st
+++ b/TelePharo-Playground.package/TlpPlayground2.class/class/openFor..st
@@ -1,0 +1,7 @@
+instance creation
+openFor: aRemotePharo 
+	
+	^ self basicNew application: self currentApplication;
+		remotePharo: aRemotePharo;
+		initialize;
+		openWithSpec

--- a/TelePharo-Playground.package/TlpPlayground2.class/instance/newDefaultPlaygroundPage.st
+++ b/TelePharo-Playground.package/TlpPlayground2.class/instance/newDefaultPlaygroundPage.st
@@ -1,0 +1,3 @@
+instance creation
+newDefaultPlaygroundPage
+	^ RemotePlaygroundPage new remotePharo: remotePharo

--- a/TelePharo-Playground.package/TlpPlayground2.class/instance/remotePharo..st
+++ b/TelePharo-Playground.package/TlpPlayground2.class/instance/remotePharo..st
@@ -1,0 +1,4 @@
+accessing
+remotePharo: anObject
+
+	remotePharo := anObject

--- a/TelePharo-Playground.package/TlpPlayground2.class/instance/remotePharo.st
+++ b/TelePharo-Playground.package/TlpPlayground2.class/instance/remotePharo.st
@@ -1,0 +1,4 @@
+accessing
+remotePharo
+
+	^ remotePharo

--- a/TelePharo-Playground.package/TlpPlayground2.class/instance/windowTitle.st
+++ b/TelePharo-Playground.package/TlpPlayground2.class/instance/windowTitle.st
@@ -1,0 +1,4 @@
+initialization
+windowTitle
+
+	^ 'RPlayground', remotePharo addressString

--- a/TelePharo-Playground.package/TlpPlayground2.class/properties.json
+++ b/TelePharo-Playground.package/TlpPlayground2.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "MarcusDenker 7/8/2021 15:22",
+	"super" : "StPlayground",
+	"category" : "TelePharo-Playground",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"remotePharo"
+	],
+	"name" : "TlpPlayground2",
+	"type" : "normal"
+}

--- a/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/lookupVar.declare..st
+++ b/TelePharo-Playground.package/TlpRemoteDoItReceiver.class/instance/lookupVar.declare..st
@@ -1,0 +1,3 @@
+lookup
+lookupVar: aString declare: aBoolean 
+	^self bindingOf: aString

--- a/TelePharo-Playground.package/TlpRemotePharo.extension/instance/openPlayground.st
+++ b/TelePharo-Playground.package/TlpRemotePharo.extension/instance/openPlayground.st
@@ -1,4 +1,4 @@
 *TelePharo-Playground
 openPlayground
 
-	^TlpPlayground openFor: self
+	^TlpPlayground2 openFor: self


### PR DESCRIPTION
This is a first step of a remote new playground.

This only adds sunclass that has a remotePharo ivar and hands this over to the class where var lookup and #doitReceiver is defined.

For now we only override the doit receiver, bindings are the next step.


